### PR TITLE
Add docs sync for dataset directories

### DIFF
--- a/tests/fixtures/data_dir_docs/LICENSE
+++ b/tests/fixtures/data_dir_docs/LICENSE
@@ -1,0 +1,1 @@
+sample license

--- a/tests/fixtures/data_dir_docs/README.md
+++ b/tests/fixtures/data_dir_docs/README.md
@@ -1,0 +1,1 @@
+sample readme

--- a/tests/fixtures/data_dir_docs/test.dat
+++ b/tests/fixtures/data_dir_docs/test.dat
@@ -1,0 +1,10 @@
+---
+$
+You are a helpful assistant.
+!
+Always be concise.
+>
+Hello!
+<
+Hi there. How can I help?
+---

--- a/tests/fixtures/data_dir_docs/train.dat
+++ b/tests/fixtures/data_dir_docs/train.dat
@@ -1,0 +1,10 @@
+---
+$
+You are a helpful assistant.
+!
+Always be concise.
+>
+Hello!
+<
+Hi there. How can I help?
+---

--- a/tests/fixtures/data_dir_docs/validation.dat
+++ b/tests/fixtures/data_dir_docs/validation.dat
@@ -1,0 +1,10 @@
+---
+$
+You are a helpful assistant.
+!
+Always be concise.
+>
+Hello!
+<
+Hi there. How can I help?
+---


### PR DESCRIPTION
## Summary
- upload: compare remote hash before pushing and allow optional README and LICENSE files
- download: cache commit hash and save README/LICENSE if present
- update adapter logic to allow and upload documentation files
- test from_dir_to_hub for directories containing documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68694f811b04832db7a2aadff624a8ab