### PR TITLE
Add push/pull commands for metadata-based syncing

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,22 @@ fifo-tool-datasets download <src> <dst> [--adapter <adapter>] [-y]
 
 The source must be in `username/repo` format. The destination can be a `.dat` file (merged) or a directory (one `.dat` per split). When downloading to a directory and `--adapter` is omitted, the CLI tries to read the adapter from the local `.hf_meta.json` file (if present from a previous download).
 
+#### `push`
+
+```bash
+fifo-tool-datasets push [<dir>] --commit-message <msg> [-y]
+```
+
+Push the dataset directory to the repo specified in `.hf_meta.json`. Defaults to the current directory.
+
+#### `pull`
+
+```bash
+fifo-tool-datasets pull [<dir>] [--adapter <adapter>] [-y]
+```
+
+Download the dataset referenced by `.hf_meta.json`. Defaults to the current directory. The adapter is read from the metadata unless overridden.
+
 #### `split`
 
 ```bash
@@ -170,7 +186,7 @@ When using `upload` or `download` with a **directory source or target**, the CLI
 
 - Upload `README.md` and `LICENSE` files from the source directory if they exist
 - Download `README.md` and `LICENSE` files from the Hub if they are present in the remote repository
-- Create a `.hf_meta.json` file when downloading, storing the adapter, download timestamp, and commit hash
+- Create a `.hf_meta.json` file when downloading, storing the adapter, repo ID, download timestamp, and commit hash
 - Use that metadata to verify the remote commit before upload
 - Auto-detect the adapter on download if `--adapter` isn't provided
 - Block uploads if the remote has changed since download, unless `-y` is passed to override
@@ -193,6 +209,12 @@ fifo-tool-datasets download username/my-dataset ./dsl_dir
 
 # Download (explicit adapter override)
 fifo-tool-datasets download username/my-dataset ./dsl_dir --adapter dsl
+
+# Push updated data
+fifo-tool-datasets push ./dsl_dir --commit-message "update"
+
+# Pull latest version
+fifo-tool-datasets pull ./dsl_dir
 
 # Split
 fifo-tool-datasets split dsl.dat --adapter dsl --to split_dsl


### PR DESCRIPTION
## 🚀 PR: Add `push` and `pull` Commands with Metadata-Based Remote Resolution

### Summary

This PR introduces two new commands to the CLI: `push` and `pull`. These commands simplify syncing a local dataset directory with the Hugging Face Hub by using metadata from `.hf_meta.json`.

### 🔁 New Commands

#### `push`

Pushes the contents of a local dataset directory to the remote repo listed in `.hf_meta.json`.

```bash 
fifo-tool-datasets push [<dir>] --commit-message <msg> [-y]
``` 

- If `<dir>` is omitted, defaults to `.` (the current working directory)
- Uses `.hf_meta.json` to retrieve the `repo_id` and `adapter` (must be present)
- Behaves like `upload`, including doc sync and safety checks
- Requires `--commit-message`

#### `pull`

Downloads the dataset from the `repo_id` listed in `.hf_meta.json`.

```bash 
fifo-tool-datasets pull [<dir>] [--adapter <adapter>] [-y]
``` 

- If `<dir>` is omitted, defaults to `.` (the current working directory)
- Behaves like `download`, including `.hf_meta.json` update and doc sync
- Uses adapter from `.hf_meta.json`, unless overridden via `--adapter`

### 🧠 Why It Matters

This improves usability by:
- Reducing the need to retype the remote repo or adapter type
- Supporting common version-control-like workflows (`pull`, `push`)
- Avoiding redundant CLI flags once metadata is established

### 📚 Docs

- Updated CLI reference section of `README.md` to include `push` and `pull` examples

## Testing
- `pytest -q`