### PR TITLE
Add diff command to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,20 @@ Show record counts and metadata for a `.dat` file or a split dataset directory. 
 fifo-tool-datasets info [<path>]
 ```
 
+#### `diff`
+
+Compare local files against the Hugging Face Hub.
+
+```bash
+fifo-tool-datasets diff [<dir>] --type <head|cache>
+```
+
+`--type head` fetches the latest files on the hub, while `--type cache` compares
+against the commit recorded in `.hf_meta.json`.
+Remote splits are converted to temporary `.dat` files using the adapter so the
+comparison matches the local format. Downloaded files are stored under the
+target directory and removed afterward.
+
 ### 🔄 Documentation and Metadata Sync
 
 When using `upload` or `download` with a **directory source or target**, the CLI automatically:
@@ -227,6 +241,9 @@ fifo-tool-datasets sort dsl.dat --adapter dsl
 
 # Info
 fifo-tool-datasets info split_dsl
+
+# Diff against the hub
+fifo-tool-datasets diff split_dsl --type head
 ```
 
 ---

--- a/fifo_tool_datasets/sdk/hf_dataset_adapters/common.py
+++ b/fifo_tool_datasets/sdk/hf_dataset_adapters/common.py
@@ -363,7 +363,13 @@ class DatasetAdapter(ABC):
             }
         )
 
-    def from_hub_to_dataset_dict(self, hub_dataset: str) -> DatasetDict:
+    def from_hub_to_dataset_dict(
+        self,
+        hub_dataset: str,
+        *,
+        revision: str | None = None,
+        cache_dir: str | None = None,
+    ) -> DatasetDict:
         """
         Loads a split dataset from the Hugging Face Hub and converts each split
         to JSON-format records using adapter-specific logic.
@@ -372,11 +378,23 @@ class DatasetAdapter(ABC):
             hub_dataset (str):
                 Name of the dataset to load from the Hugging Face Hub.
 
+        Keyword Args:
+            revision (str | None):
+                Git revision (branch, tag or commit SHA) to download. If ``None``,
+                the latest commit on the dataset's default branch is used.
+            cache_dir (str | None):
+                Directory where downloaded files should be stored. If ``None``,
+                the default Hugging Face cache location is used.
+
         Returns:
             DatasetDict:
                 A dictionary of splits ('train', 'validation', 'test').
         """
-        wide_dataset = self.from_hub_to_dataset_wide_dict(hub_dataset)
+        wide_dataset = self.from_hub_to_dataset_wide_dict(
+            hub_dataset,
+            revision=revision,
+            cache_dir=cache_dir,
+        )
 
         required_splits = ("train", "validation", "test")
 
@@ -502,7 +520,13 @@ class DatasetAdapter(ABC):
         """
 
     @abstractmethod
-    def from_hub_to_dataset_wide_dict(self, hub_dataset: str) -> DatasetDict:
+    def from_hub_to_dataset_wide_dict(
+        self,
+        hub_dataset: str,
+        *,
+        revision: str | None = None,
+        cache_dir: str | None = None,
+    ) -> DatasetDict:
         """
         Loads a wide-format dataset from the Hugging Face Hub, organized into train, validation,
         and test splits.
@@ -513,6 +537,14 @@ class DatasetAdapter(ABC):
         Args:
             hub_dataset (str):
                 The Hugging Face dataset identifier (e.g., "username/dataset").
+
+        Keyword Args:
+            revision (str | None):
+                Git revision (branch, tag or commit SHA) to download. If ``None``,
+                the latest commit on the dataset's default branch is used.
+            cache_dir (str | None):
+                Directory where downloaded files should be stored. If ``None``,
+                the default Hugging Face cache location is used.
 
         Returns:
             DatasetDict:

--- a/fifo_tool_datasets/sdk/hf_dataset_adapters/conversation.py
+++ b/fifo_tool_datasets/sdk/hf_dataset_adapters/conversation.py
@@ -253,7 +253,13 @@ class ConversationAdapter(DatasetAdapter):
         # Pylance: Type of from_dict() is partially unknown
         return Dataset.from_dict(flat_data)  # type: ignore[reportUnknownMemberType]
 
-    def from_hub_to_dataset_wide_dict(self, hub_dataset: str) -> DatasetDict:
+    def from_hub_to_dataset_wide_dict(
+        self,
+        hub_dataset: str,
+        *,
+        revision: str | None = None,
+        cache_dir: str | None = None,
+    ) -> DatasetDict:
         """
         Loads a conversation-style dataset from the Hugging Face Hub and returns it as a split
         DatasetDict.
@@ -268,6 +274,14 @@ class ConversationAdapter(DatasetAdapter):
             hub_dataset (str):
                 The Hugging Face dataset identifier (e.g., "username/dataset").
 
+        Keyword Args:
+            revision (str | None):
+                Git revision to download. If ``None``, the latest commit on the
+                dataset's default branch is used.
+            cache_dir (str | None):
+                Location to store downloaded files. Uses the default HF cache if
+                omitted.
+
         Returns:
             DatasetDict:
                 A dictionary containing train, validation, and test splits in wide format, sorted by
@@ -278,7 +292,11 @@ class ConversationAdapter(DatasetAdapter):
                 If the dataset is not split, required splits are missing, or expected fields are
                 absent.
         """
-        wide_dataset = load_dataset(hub_dataset)
+        wide_dataset = load_dataset(
+            hub_dataset,
+            revision=revision,
+            cache_dir=cache_dir,
+        )
 
         if not isinstance(wide_dataset, DatasetDict):
             raise ValueError("Expected a split DatasetDict, but got a flat Dataset.")

--- a/fifo_tool_datasets/sdk/hf_dataset_adapters/dsl.py
+++ b/fifo_tool_datasets/sdk/hf_dataset_adapters/dsl.py
@@ -238,7 +238,13 @@ class DSLAdapter(DatasetAdapter):
         # Pylance: Type of from_dict() is partially unknown
         return Dataset.from_dict(flat_data)  # type: ignore[reportUnknownMemberType]
 
-    def from_hub_to_dataset_wide_dict(self, hub_dataset: str) -> DatasetDict:
+    def from_hub_to_dataset_wide_dict(
+        self,
+        hub_dataset: str,
+        *,
+        revision: str | None = None,
+        cache_dir: str | None = None,
+    ) -> DatasetDict:
         """
         Loads a SQNA-style dataset from the Hugging Face Hub and returns it as a split DatasetDict.
 
@@ -250,6 +256,14 @@ class DSLAdapter(DatasetAdapter):
             hub_dataset (str):
                 The Hugging Face dataset identifier (e.g., "username/dataset").
 
+        Keyword Args:
+            revision (str | None):
+                Git revision to download. If ``None``, the latest commit on the
+                dataset's default branch is used.
+            cache_dir (str | None):
+                Location to store downloaded files. Uses the default HF cache if
+                omitted.
+
         Returns:
             DatasetDict:
                 A dictionary containing train, validation, and test splits with DSL-wide format.
@@ -259,7 +273,11 @@ class DSLAdapter(DatasetAdapter):
                 If the dataset is not split, required splits are missing, or expected fields are
                 absent.
         """
-        wide_dataset = load_dataset(hub_dataset)
+        wide_dataset = load_dataset(
+            hub_dataset,
+            revision=revision,
+            cache_dir=cache_dir,
+        )
 
         if not isinstance(wide_dataset, DatasetDict):
             raise ValueError("Expected a split DatasetDict, but got a flat Dataset.")

--- a/fifo_tool_datasets/sdk/hf_dataset_adapters/sqna.py
+++ b/fifo_tool_datasets/sdk/hf_dataset_adapters/sqna.py
@@ -127,7 +127,13 @@ class SQNAAdapter(DatasetAdapter):
         # Pylance: Type of from_dict() is partially unknown
         return Dataset.from_dict(flat_data)  # type: ignore[reportUnknownMemberType]
 
-    def from_hub_to_dataset_wide_dict(self, hub_dataset: str) -> DatasetDict:
+    def from_hub_to_dataset_wide_dict(
+        self,
+        hub_dataset: str,
+        *,
+        revision: str | None = None,
+        cache_dir: str | None = None,
+    ) -> DatasetDict:
         """
         Loads a SQNA-style dataset from the Hugging Face Hub and returns it as a split DatasetDict.
 
@@ -138,6 +144,14 @@ class SQNAAdapter(DatasetAdapter):
             hub_dataset (str):
                 The Hugging Face dataset identifier (e.g., "username/dataset").
 
+        Keyword Args:
+            revision (str | None):
+                Git revision to download. If ``None``, the latest commit on the
+                dataset's default branch is used.
+            cache_dir (str | None):
+                Location to store downloaded files. Uses the default HF cache if
+                omitted.
+
         Returns:
             DatasetDict:
                 A dictionary containing train, validation, and test splits with SQNA-wide format.
@@ -147,7 +161,11 @@ class SQNAAdapter(DatasetAdapter):
                 If the dataset is not split, required splits are missing, or expected fields are
                 absent.
         """
-        wide_dataset = load_dataset(hub_dataset)
+        wide_dataset = load_dataset(
+            hub_dataset,
+            revision=revision,
+            cache_dir=cache_dir,
+        )
 
         if not isinstance(wide_dataset, DatasetDict):
             raise ValueError("Expected a split DatasetDict, but got a flat Dataset.")


### PR DESCRIPTION
## ✨ New Feature: Directory Diff Command

This PR adds a new `diff` command to the CLI, allowing users to compare the contents of a local dataset directory with its corresponding version on the Hugging Face Hub.

### 🔍 Description

```bash
fifo-tool-datasets diff [<dir>] --type <head|cache>
```

- Compares all relevant files in the directory (defaults to `.` if not specified)
- Shows diffs for:
  - All `.dat` files
  - `README.md`
  - `LICENSE`
- Uses `difflib.unified_diff` for clear, readable formatting

### 🧠 Diff Type

- `--type head`: Compare against the latest version on the Hub
- `--type cache`: Compare against the commit SHA stored in `.hf_meta.json` from a prior download or push

When remote files are needed for comparison, they are temporarily downloaded to a local subdirectory and deleted after use.

### 🧪 Testing

All tests pass using:

```bash
pytest -q
```

### 📚 Documentation

- Added the `diff` command to the CLI reference in `README.md`
- Described the `--type` option and provided usage examples