### PR TITLE
Update metadata on dataset upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ When using `upload` or `download` with a **directory source or target**, the CLI
 - Upload `README.md` and `LICENSE` files from the source directory if they exist
 - Download `README.md` and `LICENSE` files from the Hub if they are present in the remote repository
 - Create a `.hf_meta.json` file when downloading, storing the adapter, repo ID, download timestamp, and commit hash
+- Update `.hf_meta.json` with the new commit hash and timestamp after a successful upload
 - Use that metadata to verify the remote commit before upload
 - Auto-detect the adapter on download if `--adapter` isn't provided
 - Block uploads if the remote has changed since download, unless `-y` is passed to override


### PR DESCRIPTION
## ✨ Metadata Update After Upload

This PR ensures that after uploading a dataset, the CLI updates `.hf_meta.json` to reflect the latest commit SHA and timestamp. This aligns `upload` behavior with `download`, improving consistency and enabling accurate `--type cache` comparisons in the `diff` command.

### ✅ Summary

- Save latest commit SHA and upload timestamp in `.hf_meta.json` after `upload`/`push`
- Clarify docstrings for `upload` and `push` commands
- Document metadata update behavior in `README.md`

### 🧪 Testing

All tests pass using:

```bash
pytest -q
```